### PR TITLE
Allow GLM style specification of Bernoulli outcomes for logistic regression

### DIFF
--- a/src/GLMNet.jl
+++ b/src/GLMNet.jl
@@ -270,6 +270,21 @@ function glmnet!(X::Matrix{Float64}, y::Vector{Float64},
     @check_and_return
 end
 
+function glmnet!(X::Matrix{Float64}, y::Vector{Float64},
+             family::Binomial;
+             kw...)
+    n = length(y)
+    newy = zeros(n, 2)
+    for i in 1:n
+        if y[i] == 0.0
+            newy[i, 1], newy[i, 2] = 1, 0
+        else
+            newy[i, 1], newy[i, 2] = 0, 1
+        end
+    end
+    return glmnet!(X, newy, family, kw...)
+end
+
 function glmnet!(X::Matrix{Float64}, y::Matrix{Float64},
              family::Binomial;
              offsets::Vector{Float64}=zeros(size(y, 1)),
@@ -350,7 +365,11 @@ glmnet(X::AbstractMatrix, y::AbstractVector, family::Distribution=Normal(); kw..
 glmnet(X::Matrix{Float64}, y::Matrix{Float64}, family::Binomial; kw...) =
     glmnet!(copy(X), copy(y), family; kw...)
 glmnet(X::Matrix, y::Matrix, family::Binomial; kw...) =
-    glmnet(float64(X), float64(y), family; kw...)
+    glmnet!(float64(X), float64(y), family; kw...)
+glmnet(X::Matrix{Float64}, y::Vector{Float64}, family::Binomial; kw...) =
+    glmnet!(copy(X), copy(y), family; kw...)
+glmnet(X::Matrix, y::Vector, family::Binomial; kw...) =
+    glmnet!(float64(X), float64(y), family; kw...)
 
 immutable GLMNetCrossValidation
     path::GLMNetPath


### PR DESCRIPTION
I often like to use `glm(X, y)` where `y` is a vector of 0's and 1's and thought it would be nice to offer the same interface for working with `glmnet`. This patch makes some quick changes to allow that to happen. Let me know if you'd like me to handle the changes in another way since I didn't spend a lot of time thinking about the cleanest way to add this functionality.

The script below gives a basic demo of the extended functionality. I can make it into a test:

```
using GLMNet
using Distributions
using Base.Test

srand(1)

invlogit(z::Real) = 1 / (1 + exp(-z))

n, p = 250_000, 2

intercept = randn()
beta = randn(p)
X = randn(n, p)
y = X * beta
for i in 1:n
    y[i] = rand(Bernoulli(invlogit(intercept + y[i])))
end

path = glmnet(X, y, Binomial())
@test abs(intercept - path.a0[end]) < 0.1
@test norm(beta - convert(Matrix{Float64}, path.betas)[:, end]) < 0.1
```
