### PR TITLE
Compat minimum version for Sys.iswindows should be 0.27

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.6
 Distributions
 StatsBase
-Compat 0.9.3
+Compat 0.27


### PR DESCRIPTION
ref https://github.com/JuliaStats/GLMNet.jl/pull/22/files#r142573147

@ararslan this also needs to be tightened in the existing tag's requires file