### PR TITLE
Bug Fixes for non-converging models

### DIFF
--- a/src/GLMNet.jl
+++ b/src/GLMNet.jl
@@ -204,9 +204,9 @@ function check_jerr(jerr, maxit)
     elseif jerr == 1000
         error("glmnet: all predictors are unpenalized")
     elseif -10001 < jerr < 0
-        warn("glment: convergence for $(-jerr)th lambda value not reached after $maxit iterations")
+        @warn("glment: convergence for $(-jerr)th lambda value not reached after $maxit iterations")
     elseif jerr < -10000
-        warn("glmnet: number of non-zero coefficients along path exceeds $nx at $(maxit+10000)th lambda value")
+        @warn("glmnet: number of non-zero coefficients along path exceeds $nx at $(maxit+10000)th lambda value")
     end
 end
 
@@ -539,7 +539,8 @@ function glmnetcv(X::AbstractMatrix, y::Union{AbstractVector,AbstractMatrix},
              weights[holdoutidx])
     end
 
-    fitloss = hcat(fits...)::Matrix{Float64}
+    filter!(x -> x != [], fits)
+    size(fits, 1) == 0 ? error("glmnetcv: no models converged properly.") : fitloss = hcat(fits...)::Matrix{Float64}
 
     ninfold = zeros(Int, nfolds)
     for f in folds


### PR DESCRIPTION
Here are some fixes I needed to do on Julia 1.0 to get the code running when models don't converge. Specifically,

- Changed `warn()` (0.6 syntax) to `@warn()`.
- For `glmnetcv`, `fits` is a vector of 1 by n vectors, which potentially contains empty vectors. I filtered out empty vectors before concatenating them, otherwise a dimension mismatch error will be thrown.