### PR TITLE
Add compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,6 +14,8 @@ glmnet_jll = "78c6b45d-5eaf-5d68-bcfb-a5a2cb06c27f"
 [compat]
 glmnet_jll = "5"
 julia = "1.3"
+Distributions = "0.20, 0.21, 0.22"
+StatsBase = "0.30, 0.31, 0.32"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
@ararslan 

Not really sure about this, right now I just went back three versions (which covers all releases of the last 6 months), but let me know what you think

It looks like Distributions is only used for dispatch between linear/logistic/poisson via `Normal/Binomial/Poisson` and StatsBase is only used for `CoefTable` to print the fit results. So almost any version would work as these were all added a long time ago.

They would probably also be easy dependencies to drop if anyone was sufficiently inclined