### PR TITLE
Merge glmnetcv from Cox into main function

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,8 +20,8 @@ glmnet_jll = "5"
 julia = "1.3"
 
 [extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test","CategoricalArrays"]
+test = ["Test", "CategoricalArrays"]

--- a/src/Multinomial.jl
+++ b/src/Multinomial.jl
@@ -188,7 +188,7 @@ glmnet(X::Matrix{Float64}, y::Matrix{Float64}, family::Multinomial; kw...) =
 glmnet(X::AbstractMatrix, y::AbstractMatrix, family::Multinomial; kw...) =
     glmnet(convert(Matrix{Float64}, X), convert(Matrix{Float64}, y), family; kw...)
 
-function glmnet(X::Matrix{Float64}, y; kw...)
+function glmnet(X::AbstractMatrix, y; kw...)
     lev = sort(unique(y))
     if length(lev) >= 2
         y = convert(Matrix{Float64}, [i == j for i in y, j in lev])
@@ -202,7 +202,7 @@ function glmnet(X::Matrix{Float64}, y; kw...)
     end
 end
 
-function glmnetcv(X::Matrix{Float64}, y; kw...)
+function glmnetcv(X::AbstractMatrix, y; kw...)
     lev = sort(unique(y))
     if length(lev) >= 2
         y = convert(Matrix{Float64}, [i == j for i in y, j in lev])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -567,8 +567,8 @@ show(IOBuffer(), coxcv.path)
 # Passing RNG makes cv deterministic
 cv1 = glmnetcv(dat[:,3:size(dat,2)], dat[:,1], dat[:,2])
 cv2 = glmnetcv(dat[:,3:size(dat,2)], dat[:,1], dat[:,2])
-@test cv1.meanloss ≉ cv2.meanloss
-@test cv1.stdloss ≉ cv2.stdloss
+@test length(cv1.meanloss) != length(cv2.meanloss) || cv1.meanloss ≉ cv2.meanloss
+@test length(cv1.stdloss) != length(cv2.stdloss) || cv1.stdloss ≉ cv2.stdloss
 cv3 = glmnetcv(dat[:,3:size(dat,2)], dat[:,1], dat[:,2]; rng=MersenneTwister(1))
 cv4 = glmnetcv(dat[:,3:size(dat,2)], dat[:,1], dat[:,2]; rng=MersenneTwister(1))
 @test cv3.meanloss ≈ cv4.meanloss

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -158,6 +158,10 @@ cv3 = glmnetcv(X, y; rng=MersenneTwister(1))
 cv4 = glmnetcv(X, y; rng=MersenneTwister(1))
 @test cv3.meanloss ≈ cv4.meanloss
 @test cv3.stdloss ≈ cv4.stdloss
+
+# Test previously ambiguous definitions
+glmnet(float.(X), y)
+glmnetcv(float.(X), y)
 end
 
 
@@ -340,7 +344,7 @@ cvShort = glmnetcv(X, yl, Binomial(); folds=[1,1,1,1,2,2,2,3,3,3],maxit=100)
 end
 
 
-    
+
 @testset "Poisson" begin ## POISSON
 df_true = [0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,3,4,4,4,4,5,5,
            5,5,5,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6]
@@ -575,7 +579,7 @@ cv4 = glmnetcv(dat[:,3:size(dat,2)], dat[:,1], dat[:,2]; rng=MersenneTwister(1))
 @test cv3.stdloss ≈ cv4.stdloss
 end
 
-@testset "Multinomial" begin ## Multinomial/multi-class 
+@testset "Multinomial" begin ## Multinomial/multi-class
 iris = DataFrame(
     SepalLength = [4.4, 5.5, 4.3, 5.1, 4.6, 4.8, 5, 4.8, 5.3, 5.4, 5.6, 6.1, 6.7, 5.6, 6.7, 6, 5.6, 6.3, 6, 6, 7.2, 7.9, 6.4, 6, 6.4, 6.8, 6.3, 7.4, 7.7, 6.1],
     SepalWidth = [3, 4.2, 3, 3.8, 3.6, 3.4, 3.4, 3, 3.7, 3.4, 3, 2.8, 3.1, 2.9, 3, 2.2, 2.5, 2.3, 3.4, 2.7, 3.6, 3.8, 2.8, 3, 2.8, 3.2, 2.8, 2.8, 2.8, 2.6],


### PR DESCRIPTION
After #50, I saw some test failures on CI at random due to the RNG tests returning fits of different lengths in rare cases. I realized the Cox version of `glmnetcv` didn't have the same guards against the fits being different lengths.

It seemed a clean fix to merge these functions together rather than having all the cross-validation logic duplicated between them.