### PR TITLE
Save losses from each fold in the final CV path

### DIFF
--- a/src/GLMNet.jl
+++ b/src/GLMNet.jl
@@ -555,7 +555,7 @@ function glmnetcv(X::AbstractMatrix, y::Union{AbstractVector{<:Number},AbstractM
     end
 
     # Do model fits and compute loss for each
-    fits = (parallel ? pmap : map)(1:nfolds) do i
+    losses = (parallel ? pmap : map)(1:nfolds) do i
         f = folds .== i
         holdoutidx = findall(f)
         modelidx = findall(!,f)
@@ -583,8 +583,8 @@ function glmnetcv(X::AbstractMatrix, y::Union{AbstractVector{<:Number},AbstractM
     end
     # Different numbers of lambdas may have converged for each fold, so trim all
     # loss vectors to the same length before aggregating
-    minLength = minimum(length.(fits))
-    fitloss = hcat([x[1:minLength] for x in fits]...)::Matrix{Float64}
+    minLength = minimum(length.(losses))
+    fitloss = hcat([x[1:minLength] for x in losses]...)::Matrix{Float64}
 
     ninfold = zeros(Int, nfolds)
     for f in folds

--- a/src/GLMNet.jl
+++ b/src/GLMNet.jl
@@ -501,6 +501,7 @@ struct GLMNetCrossValidation
     lambda::Vector{Float64}
     meanloss::Vector{Float64}
     stdloss::Vector{Float64}
+    losses::Vector{Vector{Float64}}
 end
 
 function show(io::IO, cv::GLMNetCrossValidation)
@@ -612,7 +613,7 @@ function glmnetcv(X::AbstractMatrix, y::Union{AbstractVector{<:Number},AbstractM
         stdloss[i] = sqrt(stdloss[i]/length(folds)/(nfolds - 1))
     end
 
-    GLMNetCrossValidation(path, nfolds, path.lambda, meanloss, stdloss)
+    GLMNetCrossValidation(path, nfolds, path.lambda, meanloss, stdloss, losses)
 end
 
 


### PR DESCRIPTION
This gives the ability for downstream users to determine the best fit on the path using whichever metric they want, rather than arbitrarily limiting to just mean and std