### PR TITLE
Fix determination of `nobs` in `lambda_min_ratio`

### DIFF
--- a/src/CoxNet.jl
+++ b/src/CoxNet.jl
@@ -91,7 +91,7 @@ function glmnet!(X::Matrix{Float64}, y::Matrix{Float64}, family::CoxPH;
              constraints::Array{Float64, 2}=[x for x in (-Inf, Inf), y in 1:size(X, 2)],
              dfmax::Int=size(X, 2)+1, pmax::Int=min(dfmax*2+20, size(X, 2)), 
              nlambda::Int=100,
-             lambda_min_ratio::Real=(length(y) < size(X, 2) ? 1e-2 : 1e-4),
+             lambda_min_ratio::Real=(size(y, 1) < size(X, 2) ? 1e-2 : 1e-4),
              lambda::Vector{Float64}=Float64[], tol::Real=1e-7, standardize::Bool=true,
              intercept::Bool=true, maxit::Int=1000000)
     @validate_and_init

--- a/src/GLMNet.jl
+++ b/src/GLMNet.jl
@@ -342,7 +342,7 @@ function glmnet!(X::Matrix{Float64}, y::Matrix{Float64},
              penalty_factor::Vector{Float64}=ones(size(X, 2)),
              constraints::Array{Float64, 2}=[x for x in (-Inf, Inf), y in 1:size(X, 2)],
              dfmax::Int=size(X, 2), pmax::Int=min(dfmax*2+20, size(X, 2)), nlambda::Int=100,
-             lambda_min_ratio::Real=(length(y) < size(X, 2) ? 1e-2 : 1e-4),
+             lambda_min_ratio::Real=(size(y, 1) < size(X, 2) ? 1e-2 : 1e-4),
              lambda::Vector{Float64}=Float64[], tol::Real=1e-7, standardize::Bool=true,
              intercept::Bool=true, maxit::Int=1000000, algorithm::Symbol=:newtonraphson)
     @validate_and_init
@@ -385,7 +385,7 @@ function glmnet!(X::SparseMatrixCSC{Float64,Int32}, y::Matrix{Float64},
              penalty_factor::Vector{Float64}=ones(size(X, 2)),
              constraints::Array{Float64, 2}=[x for x in (-Inf, Inf), y in 1:size(X, 2)],
              dfmax::Int=size(X, 2), pmax::Int=min(dfmax*2+20, size(X, 2)), nlambda::Int=100,
-             lambda_min_ratio::Real=(length(y) < size(X, 2) ? 1e-2 : 1e-4),
+             lambda_min_ratio::Real=(size(y, 1) < size(X, 2) ? 1e-2 : 1e-4),
              lambda::Vector{Float64}=Float64[], tol::Real=1e-7, standardize::Bool=true,
              intercept::Bool=true, maxit::Int=1000000, algorithm::Symbol=:newtonraphson)
     @validate_and_init

--- a/src/Multinomial.jl
+++ b/src/Multinomial.jl
@@ -144,7 +144,7 @@ function glmnet!(X::Matrix{Float64}, y::Matrix{Float64},
              penalty_factor::Vector{Float64}=ones(size(X, 2)),
              constraints::Array{Float64, 2}=[a for a in (-Inf, Inf), y in 1:size(X, 2)],
              dfmax::Int=size(X, 2)+1, pmax::Int=min(dfmax*2+20, size(X, 2)), nlambda::Int=100,
-             lambda_min_ratio::Real=(length(y) < size(X, 2) ? 1e-2 : 1e-4),
+             lambda_min_ratio::Real=(size(y, 1) < size(X, 2) ? 1e-2 : 1e-4),
              lambda::Vector{Float64}=Float64[], tol::Real=1e-7, standardize::Bool=true,
              intercept::Bool=true, maxit::Int=1000000, grouped_multinomial::Bool=false,  
              algorithm::Symbol=:newtonraphson)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -189,6 +189,12 @@ cv4 = glmnetcv(X, y; rng=MersenneTwister(1))
 # Test previously ambiguous definitions
 glmnet(float.(X), y)
 glmnetcv(float.(X), y)
+
+# Check for issue #72
+nobs = size(X, 2) - 1
+glmnetcv(X[1:nobs, :], y[1:nobs], nfolds=2)
+nobs = size(X, 2) + 1
+glmnetcv(X[1:nobs, :], y[1:nobs], nfolds=2)
 end
 
 
@@ -354,6 +360,12 @@ cv = glmnetcv(X, yl, Binomial(); folds=[1,1,1,1,2,2,2,3,3,3])
 # Make sure show works
 show(IOBuffer(), cv)
 show(IOBuffer(), cv.path)
+
+# Check for issue #72
+nobs = size(X, 2) - 1
+glmnetcv(X[1:nobs, :], yl[1:nobs, :], Binomial(), nfolds=2)
+nobs = size(X, 2) + 1
+glmnetcv(X[1:nobs, :], yl[1:nobs, :], Binomial(), nfolds=2)
 
 # Passing RNG makes cv deterministic
 cv1 = glmnetcv(X, yl, Binomial())
@@ -532,6 +544,12 @@ cv = glmnetcv(X, y, Poisson(); folds=[1,1,1,1,2,2,2,3,3,3])
 show(IOBuffer(), cv)
 show(IOBuffer(), cv.path)
 
+# Check for issue #72
+nobs = size(X, 2) - 1
+glmnetcv(X[1:nobs, :], y[1:nobs], Poisson(), nfolds=2)
+nobs = size(X, 2) + 1
+glmnetcv(X[1:nobs, :], y[1:nobs], Poisson(), nfolds=2)
+
 # Passing RNG makes cv deterministic
 cv1 = glmnetcv(X, y, Poisson())
 cv2 = glmnetcv(X, y, Poisson())
@@ -602,6 +620,12 @@ coxcv = glmnetcv(dat[:,3:size(dat,2)], dat[:,1], dat[:,2], lambda = cox_lambda, 
 show(IOBuffer(), coxcv)
 show(IOBuffer(), coxcv.path)
 
+# Check for issue #72
+X = dat[:,3:size(dat,2)]
+nobs = size(X, 2) - 1
+glmnetcv(X[1:nobs, :], dat[1:nobs,1], dat[1:nobs,2], nfolds=2)
+nobs = size(X, 2) + 1
+glmnetcv(X[1:nobs, :], dat[1:nobs,1], dat[1:nobs,2], nfolds=2)
 
 # Passing RNG makes cv deterministic
 cv1 = glmnetcv(dat[:,3:size(dat,2)], dat[:,1], dat[:,2])
@@ -670,6 +694,13 @@ iris_cv2 = glmnetcv(iris_x, iris_yy, Multinomial(), folds = multi_folds)
 # Make sure show works
 show(IOBuffer(), iris_cv)
 show(IOBuffer(), iris_cv.path)
+
+# Check for issue #72
+X = [iris_x iris_x]
+nobs = size(X, 2) - 1
+glmnetcv(X[1:nobs, :], iris_yy[1:nobs, :], Multinomial(), nfolds=2)
+nobs = size(X, 2) + 1
+glmnetcv(X[1:nobs, :], iris_yy[1:nobs, :], Multinomial(), nfolds=2)
 end
 
 @testset "MvNormal" begin
@@ -724,5 +755,11 @@ end
     @test preds[:, 4, :] ≈ R_preds4
     @test path.lambda ≈ R_lambda
     @test path.a0 ≈ R_a0
+
+    # Check for issue #72
+    nobs = size(X, 2) - 1
+    glmnetcv(X[1:nobs, :], Y[1:nobs, :], MvNormal())
+    nobs = size(X, 2) + 1
+    glmnetcv(X[1:nobs, :], Y[1:nobs, :], MvNormal())
 
 end


### PR DESCRIPTION
Fixes #72 

As far as I can tell, the [change](https://github.com/JuliaStats/GLMNet.jl/commit/4167f0cfafe52b40dbd889cddc123a3832d03431#diff-be44d09450fe8af7eb6ebf84f030df671cda61a91dc973fa0110b6bfd02bdaacL238) was correct, but the resulting errors were caused by the pre-existing methods using `length(y)` rather than `size(y, 1)` as `nobs` when `y` is a matrix for the purposes of determining the default value of `lambda_min_ratio`